### PR TITLE
[feature] User 더미 데이터 삽입 코드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+    implementation 'com.github.javafaker:javafaker:1.0.2'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
+++ b/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
@@ -25,7 +25,7 @@ public class DummyGenerator implements CommandLineRunner {
 	// 실행
 	@Override
 	public void run(String... args) throws Exception {
-		dummyUserGenerator();
+//		dummyUserGenerator();
 	}
 
 	// User 더미데이터 만들기

--- a/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
+++ b/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
@@ -38,3 +38,4 @@ public class DummyGenerator implements CommandLineRunner {
 		}
 	}
 }
+

--- a/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
+++ b/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
@@ -13,7 +13,7 @@ public class DummyGenerator implements CommandLineRunner {
 	private final Faker faker;
 
 	// 상수
-	private static final int COUNT = 10;
+	public static final int COUNT = 10;
 
 	// Faker 주입
 	@Autowired
@@ -29,7 +29,7 @@ public class DummyGenerator implements CommandLineRunner {
 	}
 
 	// User 더미데이터 만들기
-	private void dummyUserGenerator() {
+	public void dummyUserGenerator() {
 		for (int i = 0; i < COUNT; i++) {
 			String email = faker.internet().emailAddress();
 

--- a/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
+++ b/src/main/java/com/tourranger/common/dummy/DummyGenerator.java
@@ -1,0 +1,40 @@
+package com.tourranger.common.dummy;
+
+import com.github.javafaker.Faker;
+import com.tourranger.user.entity.User;
+import com.tourranger.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DummyGenerator implements CommandLineRunner {
+	private final UserRepository userRepository;
+	private final Faker faker;
+
+	// 상수
+	private static final int COUNT = 10;
+
+	// Faker 주입
+	@Autowired
+	public DummyGenerator(UserRepository userRepository) {
+		this.faker = new Faker();
+		this.userRepository = userRepository;
+	}
+
+	// 실행
+	@Override
+	public void run(String... args) throws Exception {
+		dummyUserGenerator();
+	}
+
+	// User 더미데이터 만들기
+	private void dummyUserGenerator() {
+		for (int i = 0; i < COUNT; i++) {
+			String email = faker.internet().emailAddress();
+
+			User user = User.builder().email(email).build();
+			userRepository.save(user);
+		}
+	}
+}

--- a/src/main/java/com/tourranger/user/repository/UserRepository.java
+++ b/src/main/java/com/tourranger/user/repository/UserRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends JpaRepository<User,Long>, UserRepositoryCustom {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 }

--- a/src/main/java/com/tourranger/user/repository/UserRepository.java
+++ b/src/main/java/com/tourranger/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.tourranger.user.repository;
+
+import com.tourranger.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User,Long>, UserRepositoryCustom {
+}

--- a/src/main/java/com/tourranger/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/tourranger/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.tourranger.user.repository;
+
+public interface UserRepositoryCustom {
+}

--- a/src/main/java/com/tourranger/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/tourranger/user/repository/UserRepositoryImpl.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class UserRepositoryImpl implements UserRepositoryCustom{
+public class UserRepositoryImpl implements UserRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 }

--- a/src/main/java/com/tourranger/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/tourranger/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.tourranger.user.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom{
+	private final JPAQueryFactory queryFactory;
+}

--- a/src/test/java/com/tourranger/common/DummyDataTest.java
+++ b/src/test/java/com/tourranger/common/DummyDataTest.java
@@ -1,0 +1,31 @@
+package com.tourranger.common;
+
+import com.tourranger.common.dummy.DummyGenerator;
+import com.tourranger.user.entity.User;
+import com.tourranger.user.repository.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DummyDataTest {
+	@Autowired
+	private DummyGenerator dummyGenerator;
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("Dummy Generator Test")
+	void dummyGeneratorTest() {
+		List<User> userList1 = userRepository.findAll();
+		dummyGenerator.dummyUserGenerator();
+		List<User> userList2 = userRepository.findAll();
+
+		assertEquals(DummyGenerator.COUNT, userList2.size() - userList1.size());
+	}
+}


### PR DESCRIPTION
## 관련 Issue

* #3 

## 변경 사항

* build.gradle에 faker 라이브러리 의존성 추가
* userRepository : QueryDSL 추후에 사용할 수도 있어 3개의 구조로 구현.
* common - dummy - DummyGenerator 클래스 만들어 어플리케이션이 실행되면 자동으로 정해진 COUNT만큼 DB에 user 넣어주는 메서드 구현
* 더미데이터 생성하는 메서드에 대한 테스트 코드 작성 

```java
List<User> beforeUserList = userRepository.findAll();
더미데이터 생성 메서드 실행
List<User> afterUserList = userRepository.findAll();

// after - before이 생성하기로 한 개수와 같은지 체크
```
* 테스트 결과
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/f4a2f6fe-f153-4164-b8a8-d65c0c2470b2)

* Github Action 통과
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/2e3cebcf-1ea0-4177-9031-e50dfc7c2d68)

## 사용한 라이브러리

### Faker

[Faker 라이브러리 깃허브 주소](https://github.com/DiUS/java-faker)

* Faker란?

fake data를 생성시키는 라이브러리.

다음의 코드처럼 코드를 작성하면 사람들이 정말로 쓸 법한, email 형식의 랜덤한 String값을 얻을 수 있다.

```java
@Component
public class DummyGenerator {
	private final Faker faker;

	// Faker 주입
	@Autowired
	public DummyGenerator() {
		this.faker = new Faker();
	}

	// User 더미데이터 만들기
	private void dummyUserGenerator() {
		String email = faker.internet().emailAddress();
	}
}
```

Application을 실행시킬 때, DB에 더미데이터를 만들어 주기 위해서 DummyGenerator에 CommandLineRunner을 구현하여 run 메서드를 오버라이딩한다.

랜덤한 이메일을 만들고, 만든 이메일로 User를 생성하여, repository에 저장하는 로직을 for문을 통해 돌려 준다.

count를 10으로 하였을 때 user table에 데이터가 10개 잘 들어가 있는 걸 확인할 수 있었다.

![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/21efed58-fce9-419d-9b61-ca68305affa9)


