### PR TITLE
[refactor] 프론트엔드-아이템 상세 페이지

### DIFF
--- a/src/main/java/com/tourranger/front/HomeController.java
+++ b/src/main/java/com/tourranger/front/HomeController.java
@@ -16,7 +16,7 @@ public class HomeController {
 		return "bannerPage";
 	}
 
-	@GetMapping("front/items/{itemId}")
+	@GetMapping("/front/items/{itemId}")
 	public String tourItem() {
 		return "tourItemPage";
 	}

--- a/src/main/java/com/tourranger/front/HomeController.java
+++ b/src/main/java/com/tourranger/front/HomeController.java
@@ -4,9 +4,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequiredArgsConstructor
+@RequestMapping("/tour-ranger")
 public class HomeController {
 
 	@GetMapping("/")
@@ -14,7 +16,7 @@ public class HomeController {
 		return "bannerPage";
 	}
 
-	@GetMapping("/items/{itemId}")
+	@GetMapping("front/items/{itemId}")
 	public String tourItem() {
 		return "tourItemPage";
 	}

--- a/src/main/java/com/tourranger/front/HomeController.java
+++ b/src/main/java/com/tourranger/front/HomeController.java
@@ -14,7 +14,7 @@ public class HomeController {
 		return "bannerPage";
 	}
 
-	@GetMapping("/items/1")
+	@GetMapping("/items/{itemId}")
 	public String tourItem() {
 		return "tourItemPage";
 	}

--- a/src/main/java/com/tourranger/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/tourranger/item/dto/ItemResponseDto.java
@@ -22,8 +22,11 @@ public class ItemResponseDto {
 	private String period;
 	private LocalDateTime departureTime;
 	private LocalDateTime arrivalTime;
-	private String travelAgency;
-	private String airline;
+	private Long travelAgencyId;
+	private String travelAgencyName;
+	private Long airlineId;
+	private String airlineName;
+	private Long thumbnailImageId;
 
 	public ItemResponseDto(Item item) {
 		this.id = item.getId();
@@ -35,7 +38,10 @@ public class ItemResponseDto {
 		this.period = item.getPeriod();
 		this.departureTime = item.getDepartureTime();
 		this.arrivalTime = item.getArrivalTime();
-		this.travelAgency = item.getTravelAgency().getName();
-		this.airline = item.getAirline().getName();
+		this.travelAgencyId = item.getTravelAgency().getId();
+		this.travelAgencyName = item.getTravelAgency().getName();
+		this.airlineId = item.getAirline().getId();
+		this.airlineName = item.getAirline().getName();
+		this.thumbnailImageId = item.getThumbnailImage().getId();
 	}
 }

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div class="container d-flex justify-content-center align-items-center vh-100">
-    <a th:href="@{/items/1}">
+    <a th:href="@{front/items/1}">
         <img alt="banner" th:src="@{/image/banner.png}" class="img-fluid" />
     </a>
 </div>

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div class="container d-flex justify-content-center align-items-center vh-100">
-    <a th:href="@{front/items/1}">
+    <a th:href="@{/tour-ranger/front/items/1}">
         <img alt="banner" th:src="@{/image/banner.png}" class="img-fluid" />
     </a>
 </div>

--- a/src/main/resources/templates/tourItemPage.html
+++ b/src/main/resources/templates/tourItemPage.html
@@ -7,22 +7,39 @@
 </head>
 <body>
 <div class="container mt-5">
+    <h2 class="card-title">오늘의 Hot Deal!</h2>
+
     <div class="card">
         <div class="card-body">
+            <h3 class="detail-header name" style="border-bottom: 2px solid black;">9월 18일 단 하루! 유럽여행 초특가 딜!</h3>
             <div class="row">
                 <div class="col-md-6">
-                    <h2 class="card-title">오늘의 Hot Deal</h2>
-                    <p class="card-text name">9월 18일 단 하루! 유럽여행 초특가 딜!</p>
-                    <img alt="Travel" class="img-fluid mb-3" id="dealImage"/>
+                    <img alt="Travel" class="img-fluid mb-3" id="thumbnailImage"/>
                 </div>
                 <div class="col-md-6 mt-3 pt-3">
-                    <div class="mb-3 mt-5 pt-5">
-                        <p class="lead">수량: <span class="quantity"></span></p>
-                        <p class="lead">기간: <span class="period"></span></p>
-                        <p class="lead">원래가격: <span class="price"></span></p>
-                        <p class="lead text-danger">할인가: <span class="discountPrice"></span></p>
+                    <div class="mb-3 mt-1 pt-1">
+                        <dt class="lead" style="display: flex; align-items: center; ">여행사 :
+                            <span class="travelAgencyName"></span>
+                            <img alt="Travel" class="img-fluid mb-3" id="travelAgencyImage"/>
+                        </dt>
+                        <dt class="lead" style="display: flex; align-items: center;">항공사 :
+                            <span class="airlineName"></span>
+                            <img alt="Airline" class="img-fluid mb-3" id="airlineImage"/>
+                        </dt>
+                        <dt>일정</dt>
+                        <dd class="period"></dd>
+                        <dt>한국출발🛫</dt>
+                        <dd class="departureTime"></dd>
+<!--                        <p class="lead">여행 출발일시: <span class="departureTime"></span></p>-->
+                        <dt>한국도착🛬</dt>
+                        <dd class="arrivalTime"></dd>
+<!--                        <p class="lead">여행 도착일시: <span class="arrivalTime"></span></p>-->
+                        <p class="lead" id="price">상품 가격: <span class="price" ></span></p>
+                        <p class="lead text-danger" style="font-weight: bold">할인적용가: <span class="discountPrice"></span></p>
                         <label for="email" class="form-label">주문자 Email</label>
                         <input type="email" class="form-control" id="email" placeholder="Enter your email">
+                        <dt>예약현황</dt>
+                        <dd>총 <span class="maxQuantity" style="font-weight: bold;color: darkblue;"></span>좌석 중 잔여 좌석 <span class="currentQuantity" style="font-weight: bold; color: darkred;"></span>개 남았습니다.</dd>
                     </div>
                     <button class="btn btn-primary" id="purchaseButton">구매하기</button>
                 </div>
@@ -33,16 +50,28 @@
 
 <script>
     function fetchItem() {
+
+
+
         //getItem
         fetch("/tour-ranger/items/1")
             .then(response => response.json())
             .then(data => {
                 const name = data.name;
-                const quantity = data.quantity;
-                const period = data.period;
                 const price = data.price;
                 const discountPrice = data.discountPrice;
-                window.id = data.id;
+                const currentQuantity = data.currentQuantity;
+                const maxQuantity = data.maxQuantity;
+                const departureTime = data.departureTime;
+                const arrivalTime = data.arrivalTime;
+                const travelAgencyId = data.travelAgencyId;
+                const travelAgencyName = data.travelAgencyName;
+                const airlineId = data.airlineId;
+                const airlineName = data.airlineName;
+                const thumbnailImageId = data.thumbnailImageId;
+                const period = data.period;
+
+                // window.id = data.id;
 
                 // 숫자 포맷을 위한 옵션 설정
                 const numberFormatOptions = {
@@ -56,35 +85,33 @@
                 const formattedOriginalPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(price);
                 const formattedDiscountPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(discountPrice);
 
+                document.querySelector(".period").textContent = period;
                 document.querySelector(".name").textContent = name;
-                document.querySelector(".period").textContent = period + "일";
-                document.querySelector(".quantity").textContent = quantity;
                 document.querySelector(".price").textContent = formattedOriginalPrice;
                 document.querySelector(".discountPrice").textContent = formattedDiscountPrice;
+                document.querySelector(".currentQuantity").textContent =currentQuantity;
+                document.querySelector(".maxQuantity").textContent = maxQuantity;
+                document.querySelector(".departureTime").textContent = departureTime;
+                document.querySelector(".arrivalTime").textContent = arrivalTime;
+                document.querySelector(".travelAgencyName").textContent = travelAgencyName;
+                document.querySelector(".airlineName").textContent = airlineName;
 
-                fetchImage(window.id);
+                //가격 할인이 적용되었을 때, 현재가격 취소선처리
+                if (price !== discountPrice) {
+                    const priceText = document.getElementById("price"); // id가 "priceSpan"인 요소 선택
+                    priceText.style.textDecoration = "line-through"; // 취소선 스타일 적용
+                }
+
+                fetchImage(airlineId,travelAgencyId,thumbnailImageId);
             })
             .catch(error => {
                 console.error("Error fetching item data:", error);
             });
 
-        function fetchImage(itemId) {
-            fetch('/tour-ranger/items/' + itemId + '/images')
-                .then(response => response.json())
-                .then(dataList => {
-                    if (dataList.length > 0) {
-                        const imageData = dataList[0];
-                        const imageId = imageData.id;
-
-                        document.getElementById("dealImage").src = "/tour-ranger/images/" + imageId;
-
-                    } else {
-                        console.error("No image data found.");
-                    }
-                })
-                .catch(error => {
-                    console.error("Error fetching image data:", error);
-                });
+        function fetchImage(airlineId, travelAgencyId,thumbnailImageId) {
+            document.getElementById("airlineImage").src = "/tour-ranger/airlines/" + airlineId;
+            document.getElementById("travelAgencyImage").src = "/tour-ranger/travelAgencies/" + travelAgencyId;
+            document.getElementById("thumbnailImage").src = "/tour-ranger/thumbnailImages/" + thumbnailImageId;
         }
 
         //구매하기 버튼 클릭

--- a/src/main/resources/templates/tourItemPage.html
+++ b/src/main/resources/templates/tourItemPage.html
@@ -8,7 +8,7 @@
 <body>
 <div class="container mt-5">
     <h2 class="card-title">오늘의 Hot Deal!</h2>
-
+    <input id="this-item" value="" style="display: none;">
     <div class="card">
         <div class="card-body">
             <h3 class="detail-header name" style="border-bottom: 2px solid black;">9월 18일 단 하루! 유럽여행 초특가 딜!</h3>
@@ -52,6 +52,8 @@
     function fetchItem() {
         const url = window.location.href;
         let itemId = url.split("/").pop(); //url에서 끝값에 위치한 id번호 가져오기
+        document.getElementById("this-item").value = itemId;
+
         //getItem
         fetch(`/tour-ranger/items/${itemId}`)
             .then(response => response.json())
@@ -95,11 +97,9 @@
                 document.querySelector(".travelAgencyName").textContent = travelAgencyName;
                 document.querySelector(".airlineName").textContent = airlineName;
 
-                //가격 할인이 적용되었을 때, 현재가격 취소선처리
-                if (price !== discountPrice) {
-                    const priceText = document.getElementById("price"); // id가 "priceSpan"인 요소 선택
-                    priceText.style.textDecoration = "line-through"; // 취소선 스타일 적용
-                }
+                const priceText = document.getElementById("price"); // id가 "priceSpan"인 요소 선택
+                priceText.style.textDecoration = "line-through"; // 취소선 스타일 적용
+
 
                 fetchImage(airlineId,travelAgencyId,thumbnailImageId);
             })
@@ -116,7 +116,7 @@
         //구매하기 버튼 클릭
         document.getElementById("purchaseButton").addEventListener("click", function () {
             const email = document.getElementById("email").value;
-            const itemId = window.id;
+            const itemId = document.getElementById("this-item").value;
             if (!email) {
                 alert("이메일을 입력해 주세요.");
                 return;

--- a/src/main/resources/templates/tourItemPage.html
+++ b/src/main/resources/templates/tourItemPage.html
@@ -139,6 +139,7 @@
                         alert(errorMessage);
                     } else {
                         alert("구매에 성공 했습니다.");
+                        window.location.href = "/tour-ranger/front/items/"+itemId;
                     }
                 })
                 .catch(error => {

--- a/src/main/resources/templates/tourItemPage.html
+++ b/src/main/resources/templates/tourItemPage.html
@@ -50,11 +50,10 @@
 
 <script>
     function fetchItem() {
-
-
-
+        const url = window.location.href;
+        let itemId = url.split("/").pop(); //url에서 끝값에 위치한 id번호 가져오기
         //getItem
-        fetch("/tour-ranger/items/1")
+        fetch(`/tour-ranger/items/${itemId}`)
             .then(response => response.json())
             .then(data => {
                 const name = data.name;

--- a/src/main/resources/templates/tourItemPage.html
+++ b/src/main/resources/templates/tourItemPage.html
@@ -29,9 +29,9 @@
                         <dt>일정</dt>
                         <dd class="period"></dd>
                         <dt>한국출발🛫</dt>
-                        <dd class="departureTime" type="datetime-local"></dd>
+                        <dd class="departureTime"></dd>
                         <dt>한국도착🛬</dt>
-                        <dd class="arrivalTime" type="datetime-local"></dd>
+                        <dd class="arrivalTime"></dd>
                         <p class="lead" id="price">상품 가격: <span class="price" ></span></p>
                         <p class="lead text-danger" style="font-weight: bold">할인적용가: <span class="discountPrice"></span></p>
                         <label for="email" class="form-label">주문자 Email</label>

--- a/src/main/resources/templates/tourItemPage.html
+++ b/src/main/resources/templates/tourItemPage.html
@@ -29,11 +29,9 @@
                         <dt>일정</dt>
                         <dd class="period"></dd>
                         <dt>한국출발🛫</dt>
-                        <dd class="departureTime"></dd>
-<!--                        <p class="lead">여행 출발일시: <span class="departureTime"></span></p>-->
+                        <dd class="departureTime" type="datetime-local"></dd>
                         <dt>한국도착🛬</dt>
-                        <dd class="arrivalTime"></dd>
-<!--                        <p class="lead">여행 도착일시: <span class="arrivalTime"></span></p>-->
+                        <dd class="arrivalTime" type="datetime-local"></dd>
                         <p class="lead" id="price">상품 가격: <span class="price" ></span></p>
                         <p class="lead text-danger" style="font-weight: bold">할인적용가: <span class="discountPrice"></span></p>
                         <label for="email" class="form-label">주문자 Email</label>
@@ -86,14 +84,31 @@
                 const formattedOriginalPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(price);
                 const formattedDiscountPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(discountPrice);
 
+
+                function formatDate(dateTimeString) {
+                    const options = {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit"
+                    };
+                    const date = new Date(dateTimeString);
+                    return date.toLocaleString("en-US", options);
+                }
+
+                const formattedDepartureTime = formatDate(departureTime);
+                const formattedArrivalTime = formatDate(arrivalTime);
+                console.log(formattedDepartureTime);
+
                 document.querySelector(".period").textContent = period;
                 document.querySelector(".name").textContent = name;
                 document.querySelector(".price").textContent = formattedOriginalPrice;
                 document.querySelector(".discountPrice").textContent = formattedDiscountPrice;
                 document.querySelector(".currentQuantity").textContent =currentQuantity;
                 document.querySelector(".maxQuantity").textContent = maxQuantity;
-                document.querySelector(".departureTime").textContent = departureTime;
-                document.querySelector(".arrivalTime").textContent = arrivalTime;
+                document.querySelector(".departureTime").textContent = formattedDepartureTime;
+                document.querySelector(".arrivalTime").textContent = formattedArrivalTime;
                 document.querySelector(".travelAgencyName").textContent = travelAgencyName;
                 document.querySelector(".airlineName").textContent = airlineName;
 

--- a/src/main/resources/templates/tourItemPage.html
+++ b/src/main/resources/templates/tourItemPage.html
@@ -94,7 +94,7 @@
                         minute: "2-digit"
                     };
                     const date = new Date(dateTimeString);
-                    return date.toLocaleString("en-US", options);
+                    return date.toLocaleString("ko-KR", options);
                 }
 
                 const formattedDepartureTime = formatDate(departureTime);


### PR DESCRIPTION
## 관련 Issue
* #31 

## 변경 사항
- Item 내 필드 추가에 따라 프론트엔드에 반영
- 썸네일 이미지, 항공사 이미지, 여행사 이미지 추가
- HomeController 상품 상세페이지 호출 경로 동적으로 변경 (/items/1) -> (/items/{itemId})
- 구매 완료 시 페이지 refresh
## 구성 화면
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/131952511/ac564e0a-605f-4b2d-b894-6617a9488580)

