### PR TITLE
[feature] 배너페이지 화면 기능추가

### DIFF
--- a/src/main/java/com/tourranger/item/controller/ItemController.java
+++ b/src/main/java/com/tourranger/item/controller/ItemController.java
@@ -5,24 +5,39 @@ import com.tourranger.item.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/tour-ranger")
 @Tag(name = "Item API", description = "Item에 관련된 API 정보를 담고 있습니다.")
 public class ItemController {
-	private final ItemService itemService;
+    private final ItemService itemService;
 
-	@Operation(summary = "상품 조회", description = "ItemId에 맞는 상품의 정보를 조회합니다.")
-	@GetMapping("/items/{itemId}")
-	public ResponseEntity<ItemResponseDto> getItem(@PathVariable Long itemId) {
-		ItemResponseDto responseDto = itemService.getItem(itemId);
-		return ResponseEntity.ok().body(responseDto);
-	}
+    @Operation(summary = "상품 조회", description = "ItemId에 맞는 상품의 정보를 조회합니다.")
+    @GetMapping("/items/{itemId}")
+    public ResponseEntity<ItemResponseDto> getItem(@PathVariable Long itemId) {
+        ItemResponseDto responseDto = itemService.getItem(itemId);
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @Operation(summary = "상품리스트 조회", description = "상품의 정보를 조회합니다.")
+    @GetMapping("/items")
+    public ResponseEntity<List<ItemResponseDto>> getItemList(@RequestParam(name = "search", required = false) String search,
+                                                          @RequestParam(name = "condition", required = false) String condition,
+                                                          Pageable pageable) throws UnsupportedEncodingException {
+        //검색어 입력으로 조회하는 경우
+        if (search != null && !search.isEmpty()) {
+            return ResponseEntity.ok().body(itemService.getSearchedItemList(search, condition, pageable));
+        }
+        //일반 조회하는 경우-Id순
+        else
+            return ResponseEntity.ok().body(itemService.getItemList(pageable));
+    }
 
 }

--- a/src/main/java/com/tourranger/item/controller/ItemController.java
+++ b/src/main/java/com/tourranger/item/controller/ItemController.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 @RestController
@@ -30,7 +29,7 @@ public class ItemController {
     @GetMapping("/items")
     public ResponseEntity<List<ItemResponseDto>> getItemList(@RequestParam(name = "search", required = false) String search,
                                                           @RequestParam(name = "condition", required = false) String condition,
-                                                          Pageable pageable) throws UnsupportedEncodingException {
+                                                          Pageable pageable) {
         //검색어 입력으로 조회하는 경우
         if (search != null && !search.isEmpty()) {
             return ResponseEntity.ok().body(itemService.getSearchedItemList(search, condition, pageable));

--- a/src/main/java/com/tourranger/item/repository/ItemRepository.java
+++ b/src/main/java/com/tourranger/item/repository/ItemRepository.java
@@ -1,6 +1,8 @@
 package com.tourranger.item.repository;
 
 import com.tourranger.item.entity.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,15 @@ import java.util.Optional;
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
 	Optional<Item> findTopByOrderByIdDesc();
+
+	Page<Item> findAllByOrderById(Pageable pageable);
+
+	//이름검색(조건-최신순)
+	Page<Item> findByNameContainingOrderByIdDesc(String search, Pageable pageable);
+
+	//이름검색(조건-가격 낮은순)
+	Page<Item> findByNameContainingOrderByDiscountPrice(String search, Pageable pageable);
+
+	//이름검색(조건-가격 높은순)
+	Page<Item> findByNameContainingOrderByDiscountPriceDesc(String search, Pageable pageable);
 }

--- a/src/main/java/com/tourranger/item/service/ItemService.java
+++ b/src/main/java/com/tourranger/item/service/ItemService.java
@@ -3,7 +3,6 @@ package com.tourranger.item.service;
 import com.tourranger.item.dto.ItemResponseDto;
 import org.springframework.data.domain.Pageable;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 public interface ItemService {
@@ -27,5 +26,5 @@ public interface ItemService {
      * @param pageable  사용자가 누른 페이지정보
      * @return 검색결과가 반영된 해당 페이지의 ItemList
      */
-    List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable) throws UnsupportedEncodingException;
+    List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable);
 }

--- a/src/main/java/com/tourranger/item/service/ItemService.java
+++ b/src/main/java/com/tourranger/item/service/ItemService.java
@@ -1,12 +1,31 @@
 package com.tourranger.item.service;
 
 import com.tourranger.item.dto.ItemResponseDto;
+import org.springframework.data.domain.Pageable;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 public interface ItemService {
-	/**
-	 * 상품 조회
-	 * @param itemId 조회할 상품 ID
-	 * @return 조회한 상품 정보
-	 */
-	ItemResponseDto getItem(Long itemId);
+    /**
+     * 상품 조회
+     *
+     * @param itemId 조회할 상품 ID
+     * @return 조회한 상품 정보
+     */
+    ItemResponseDto getItem(Long itemId);
+
+    /**
+     * @param pageable 프론트엔드에서 보내주는 페이지정보 예: page=1&size=5
+     * @return 해당페이지의 ItemList
+     */
+    List<ItemResponseDto> getItemList(Pageable pageable);
+
+    /**
+     * @param search    검색창에 입력한 String값
+     * @param condition 검색 당시 선택한 검색조건(최신순/가격 높은순/가격 낮은 순)
+     * @param pageable  사용자가 누른 페이지정보
+     * @return 검색결과가 반영된 해당 페이지의 ItemList
+     */
+    List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable) throws UnsupportedEncodingException;
 }

--- a/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
@@ -6,24 +6,50 @@ import com.tourranger.item.dto.ItemResponseDto;
 import com.tourranger.item.entity.Item;
 import com.tourranger.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ItemServiceImpl implements ItemService {
 
-	private final ItemRepository itemRepository;
-	@Override
-	public ItemResponseDto getItem(Long itemId) {
-		Item item = findItem(itemId);
-		ItemResponseDto responseDto = new ItemResponseDto(item);
-		return responseDto;
-	}
+    private final ItemRepository itemRepository;
 
-	public Item findItem(Long id) {
-		return itemRepository.findById(id).orElseThrow(() ->
-				new CustomException(CustomErrorCode.ITEM_NOT_FOUND, null)
-		);
-	}
+    @Override
+    public ItemResponseDto getItem(Long itemId) {
+        Item item = findItem(itemId);
+        ItemResponseDto responseDto = new ItemResponseDto(item);
+        return responseDto;
+    }
+
+    @Override
+    public List<ItemResponseDto> getItemList(Pageable pageable) {
+        return itemRepository.findAllByOrderById(pageable).stream().map(ItemResponseDto::new).toList();
+    }
+
+    @Override
+    public List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable) throws UnsupportedEncodingException {
+        System.out.println("search= " + search);
+        System.out.println("condition= " + condition);
+
+        return switch (condition) {
+            case "latest" -> // 최신순
+                    itemRepository.findByNameContainingOrderByIdDesc(search, pageable).stream().map(ItemResponseDto::new).toList();
+            case "priceLowToHigh" -> // 가격 낮은순
+                    itemRepository.findByNameContainingOrderByDiscountPrice(search, pageable).stream().map(ItemResponseDto::new).toList();
+            case "priceHighToLow" -> // 가격 높은순
+                    itemRepository.findByNameContainingOrderByDiscountPriceDesc(search, pageable).stream().map(ItemResponseDto::new).toList();
+            default -> null;
+        };
+    }
+
+    public Item findItem(Long id) {
+        return itemRepository.findById(id).orElseThrow(() ->
+                new CustomException(CustomErrorCode.ITEM_NOT_FOUND, null)
+        );
+    }
 
 }

--- a/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
@@ -32,8 +32,6 @@ public class ItemServiceImpl implements ItemService {
 
     @Override
     public List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable) throws UnsupportedEncodingException {
-        System.out.println("search= " + search);
-        System.out.println("condition= " + condition);
 
         return switch (condition) {
             case "latest" -> // 최신순

--- a/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 @Service
@@ -31,7 +30,7 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
-    public List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable) throws UnsupportedEncodingException {
+    public List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable) {
 
         return switch (condition) {
             case "latest" -> // 최신순

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -60,8 +60,7 @@
                 <a class="page-link" href="#" tabindex="-1" aria-disabled="true" onclick="goPreviousPage()">Previous</a>
             </li>
             <!-- 페이지 버튼들 -->
-            <li class="page-item active" id="page-button-0" aria-current="page"><a class="page-link" href="#"
-                                                                                   onclick="changePage(0)">1</a></li>
+            <li class="page-item active" id="page-button-0" aria-current="page"><a class="page-link" href="#" onclick="changePage(0)">1</a></li>
             <li class="page-item" id="page-button-1"><a class="page-link" href="#" onclick="changePage(1)">2</a></li>
             <li class="page-item" id="page-button-2"><a class="page-link" href="#" onclick="changePage(2)">3</a></li>
             <li class="page-item" id="page-button-3"><a class="page-link" href="#" onclick="changePage(3)">4</a></li>
@@ -169,13 +168,11 @@
                 responseDto.forEach(function (responseDto) {
                     let itemId = responseDto.id;
                     let name = responseDto.name;
-                    let price = responseDto.price;
                     let discountPrice = responseDto.discountPrice;
                     let period = responseDto.period;
                     let airlineId = responseDto.airlineId;
                     let airlineName = responseDto.airlineName;
                     let thumbnailImageId = responseDto.thumbnailImageId;
-                    let travelAgencyId = responseDto.travelAgencyId;
                     let departureTime = responseDto.departureTime;
                     let arrivalTime = responseDto.arrivalTime;
 
@@ -188,7 +185,6 @@
                     };
 
                     // 천 단위 구분 기호를 포함한 금액 포맷팅
-                    // const formattedOriginalPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(price);
                     const formattedDiscountPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(discountPrice);
 
                     function formatDate(dateTimeString) {

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -3,13 +3,356 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/paginationjs/2.1.4/pagination.css"/>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
+<style>
+    .list-inner {
+        outline: solid 0.5px black;
+    }
+</style>
 <body>
-<div class="container d-flex justify-content-center align-items-center vh-100">
+<div class="container d-flex justify-content-center align-items-center ">
     <a th:href="@{/tour-ranger/front/items/1}">
-        <img alt="banner" th:src="@{/image/banner.png}" class="img-fluid" />
+        <img alt="banner" th:src="@{/image/banner.png}" class="img-fluid"
+             style="max-width: 50%; height: 100%; padding: 25px; margin-left:30%;"/>
     </a>
 </div>
+
+<!-- 검색창 표시 -->
+<div class="container mt-5">
+    <h1 class="text-center">Search</h1>
+    <div class="row justify-content-center mt-3">
+        <div class="col-md-4">
+            <form class="form-inline">
+                <input type="text" id="search" class="form-control mr-2" placeholder="상품 이름으로 검색">
+                <button type="submit" class="btn btn-primary" onclick="searchItems(0,5)">검색</button>
+                <div class="col-md-2 mt-3 mt-md-0">
+                    <select id="condition" class="form-control">
+                        <option value="latest">최신순</option>
+                        <option value="priceLowToHigh">가격 낮은 순</option>
+                        <option value="priceHighToLow">가격 높은 순</option>
+                    </select>
+                </div>
+            </form>
+        </div>
+
+    </div>
+
+</div>
+
+
+<!-- 상품 목록 표시 -->
+<table>
+    <div id="itemTableBody">
+        <!-- 아이템 목록이 여기에 동적으로 추가될 것입니다. -->
+    </div>
+</table>
+
+<!-- 페이지네이션 -->
+<div class="d-flex justify-content-center">
+    <nav aria-label="...">
+        <ul class="pagination" id="pagination">
+            <!-- 이전 페이지로 가기 버튼 -->
+            <li class="page-item disabled" id="page-button-previous">
+                <a class="page-link" href="#" tabindex="-1" aria-disabled="true" onclick="goPreviousPage()">Previous</a>
+            </li>
+            <!-- 페이지 버튼들 -->
+            <li class="page-item active" id="page-button-0" aria-current="page"><a class="page-link" href="#"
+                                                                                   onclick="changePage(0)">1</a></li>
+            <li class="page-item" id="page-button-1"><a class="page-link" href="#" onclick="changePage(1)">2</a></li>
+            <li class="page-item" id="page-button-2"><a class="page-link" href="#" onclick="changePage(2)">3</a></li>
+            <li class="page-item" id="page-button-3"><a class="page-link" href="#" onclick="changePage(3)">4</a></li>
+            <li class="page-item" id="page-button-4"><a class="page-link" href="#" onclick="changePage(4)">5</a></li>
+            <li class="page-item" id="page-button-5"><a class="page-link" href="#" onclick="changePage(5)">6</a></li>
+            <li class="page-item" id="page-button-6"><a class="page-link" href="#" onclick="changePage(6)">7</a></li>
+            <li class="page-item" id="page-button-7"><a class="page-link" href="#" onclick="changePage(7)">8</a></li>
+            <li class="page-item" id="page-button-8"><a class="page-link" href="#" onclick="changePage(8)">9</a></li>
+            <li class="page-item" id="page-button-9"><a class="page-link" href="#" onclick="changePage(9)">10</a></li>
+            <!-- 다음 페이지로 가기 버튼 -->
+            <li class="page-item" id="page-button-next">
+                <a class="page-link" href="#" onclick="goNextPage()">Next</a>
+            </li>
+        </ul>
+    </nav>
+</div>
+<script>
+
+    let itemsPerPage = 5; // 페이지당 아이템 수
+    let currentPage = 0; // 현재 페이지
+    let searched = false;
+
+    function changePage(newPage) {
+
+        // 현재 페이지 버튼의 active 클래스 제거
+        const previousActiveButton = document.querySelector("#pagination .page-item.active");
+        previousActiveButton.classList.remove("active");
+
+        // 선택한 페이지 버튼에 active 클래스 추가
+        const newActiveButton = document.querySelector(`#pagination #page-button-${newPage}`);
+        newActiveButton.classList.add("active");
+
+        currentPage = newPage;
+
+        // 이전 버튼과 다음 버튼 상태 업데이트 0이하 못누르도록, 총 페이지 수만큼 못누르도록 로직 필요
+        const previousButton = document.querySelector("#page-button-previous");
+        // const nextButton = document.querySelector("#page-button-next");
+
+        if (currentPage === 0) {
+            previousButton.classList.add("disabled");
+        } else {
+            previousButton.classList.remove("disabled");
+        }
+
+        // // 여기서 totalPages는 총 페이지 수에 맞게 변경해야 합니다.
+        // // const totalPages = 10; // 예시로 6으로 설정
+        // if (currentPage === totalPages - 1) {
+        //     nextButton.classList.add("disabled");
+        // } else {
+        //     nextButton.classList.remove("disabled");
+        // }
+
+        //검색어 입력한 상태인 경우, 검색결과에 대한 페이지 이벤트
+        if (searched)
+            searchItems(currentPage, itemsPerPage);
+        else
+            displayItems(currentPage, itemsPerPage);
+    }
+
+    function goNextPage() {
+        // 현재 페이지 버튼의 active 클래스 제거
+        const previousActiveButton = document.querySelector("#pagination .page-item.active");
+        previousActiveButton.classList.remove("active");
+
+        // next 페이지 버튼에 active 클래스 추가
+        const newActiveButton = document.querySelector(`#pagination #page-button-next`);
+        newActiveButton.classList.add("active");
+        currentPage = currentPage + 1;
+        if (searched)
+            searchItems(currentPage, itemsPerPage);
+        else
+            displayItems(currentPage, itemsPerPage);
+    }
+
+    function goPreviousPage() {
+        if (currentPage > 0) {
+            // 현재 페이지 버튼의 active 클래스 제거
+            const previousActiveButton = document.querySelector("#pagination .page-item.active");
+            previousActiveButton.classList.remove("active");
+
+            // 선택한 페이지 버튼에 active 클래스 추가
+            const newActiveButton = document.querySelector(`#pagination #page-button-previous`);
+            newActiveButton.classList.add("active");
+
+            currentPage = currentPage - 1;
+            if (searched)
+                searchItems(currentPage, itemsPerPage);
+            else
+                displayItems(currentPage, itemsPerPage);
+        }
+    }
+
+    function searchItems(page, size) {
+        let search = document.getElementById("search").value;
+        let condition = document.getElementById("condition").value;
+        searched = true;
+
+        fetch(`/tour-ranger/items?search=${search}&condition=${condition}&page=${page}&size=${size}`)
+            .then(function (response) {
+                return response.json();
+            })
+            .then(function (responseDto) {
+                $('#itemTableBody').empty();
+
+                responseDto.forEach(function (responseDto) {
+                    let itemId = responseDto.id;
+                    let name = responseDto.name;
+                    let price = responseDto.price;
+                    let discountPrice = responseDto.discountPrice;
+                    let period = responseDto.period;
+                    let airlineId = responseDto.airlineId;
+                    let airlineName = responseDto.airlineName;
+                    let thumbnailImageId = responseDto.thumbnailImageId;
+                    let travelAgencyId = responseDto.travelAgencyId;
+                    let departureTime = responseDto.departureTime;
+                    let arrivalTime = responseDto.arrivalTime;
+
+                    // 숫자 포맷을 위한 옵션 설정
+                    const numberFormatOptions = {
+                        style: "currency",
+                        currency: "KRW", // 원화 표시
+                        minimumFractionDigits: 0,
+                        maximumFractionDigits: 0,
+                    };
+
+                    // 천 단위 구분 기호를 포함한 금액 포맷팅
+                    // const formattedOriginalPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(price);
+                    const formattedDiscountPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(discountPrice);
+
+                    function formatDate(dateTimeString) {
+                        const options = {
+                            year: "numeric",
+                            month: "long",
+                            day: "numeric"
+                        };
+                        const date = new Date(dateTimeString);
+                        return date.toLocaleString("ko-KR", options);
+                    }
+
+                    const formattedDepartureDate = formatDate(departureTime);
+                    const formattedArrivalDate = formatDate(arrivalTime);
+
+                    let temp_html = `<div class="card mb-3" style="max-width: 1040px; height: 100%;  margin:auto;">
+                                        <div class="row g-0">
+                                            <div class="col-md-4">
+                                                <img src="/tour-ranger/thumbnailImages/${thumbnailImageId}" class="img-fluid rounded-start" alt="...">
+                                            </div>
+                                            <div class="col-md-8" >
+                                                <div class="card-body">
+                                                    <h5 class="card-title">${name}</h5>
+                                                    <div class="period" style="display: flex; align-items: center; ">
+                                                        <dl>
+                                                            <dt>여행일정</dt>
+                                                            <dd>${period}</dd>
+                                                        </dl>
+                                                        <dl style="padding-left: 50px;">
+                                                            <dt>여행기간</dt>
+                                                            <dd>${formattedDepartureDate} ~ ${formattedArrivalDate}</dd>
+                                                        </dl>
+                                                    </div>
+                                                    <ul class="flight">
+                                                        <div class="no">상품번호 ${itemId}</div>
+                                                        <img src="/tour-ranger/airlines/${airlineId}" style="width: 25px;height: 25px">${airlineName}
+                                                        <strong>${formattedDiscountPrice}</strong><em>원 ~</em>
+                                                        <button class="btn-type-1 color--black" name="btnDetail" data-no="1" data-id="${itemId}"
+                                                                value="${itemId}" onclick="showItemButton(this)">자세히보기
+                                                        </button>
+                                                    </ul>
+
+                                            </div>
+                                        </div>
+                                    </div>`
+                    $('#itemTableBody').append(temp_html);
+                });
+            }).catch(function (error) {
+            console.error("Item 리스트 불러오기 실패", error);
+        })
+    }
+
+
+    function displayItems(page, size) {
+
+        fetch(`/tour-ranger/items?page=${page}&size=${size}`)
+            .then(function (response) {
+                return response.json();
+            })
+            .then(function (responseDto) {
+                $('#itemTableBody').empty();
+
+                responseDto.forEach(function (responseDto) {
+                    let itemId = responseDto.id;
+                    let name = responseDto.name;
+                    let price = responseDto.price;
+                    let discountPrice = responseDto.discountPrice;
+                    let period = responseDto.period;
+                    let airlineId = responseDto.airlineId;
+                    let airlineName = responseDto.airlineName;
+                    let thumbnailImageId = responseDto.thumbnailImageId;
+                    let travelAgencyId = responseDto.travelAgencyId;
+                    let departureTime = responseDto.departureTime;
+                    let arrivalTime = responseDto.arrivalTime;
+
+                    // 숫자 포맷을 위한 옵션 설정
+                    const numberFormatOptions = {
+                        style: "currency",
+                        currency: "KRW", // 원화 표시
+                        minimumFractionDigits: 0,
+                        maximumFractionDigits: 0,
+                    };
+
+                    // 천 단위 구분 기호를 포함한 금액 포맷팅
+                    const formattedOriginalPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(price);
+                    const formattedDiscountPrice = new Intl.NumberFormat("ko-KR", numberFormatOptions).format(discountPrice);
+
+                    function formatDate(dateTimeString) {
+                        const options = {
+                            year: "numeric",
+                            month: "long",
+                            day: "numeric"
+                        };
+                        const date = new Date(dateTimeString);
+                        return date.toLocaleString("ko-KR", options);
+                    }
+
+                    const formattedDepartureDate = formatDate(departureTime);
+                    const formattedArrivalDate = formatDate(arrivalTime);
+
+                    let temp_html = `<div class="card mb-3" style="max-width: 1040px; height: 100%;  margin:auto;">
+                                        <div class="row g-0">
+                                            <div class="col-md-4">
+                                                <img src="/tour-ranger/thumbnailImages/${thumbnailImageId}" class="img-fluid rounded-start" alt="...">
+                                            </div>
+                                            <div class="col-md-8" >
+                                                <div class="card-body">
+                                                    <h5 class="card-title">${name}</h5>
+                                                    <div class="period" style="display: flex; align-items: center; ">
+                                                        <dl>
+                                                            <dt>여행일정</dt>
+                                                            <dd>${period}</dd>
+                                                        </dl>
+                                                        <dl style="padding-left: 50px;">
+                                                            <dt>여행기간</dt>
+                                                            <dd>${formattedDepartureDate} ~ ${formattedArrivalDate}</dd>
+                                                        </dl>
+                                                    </div>
+                                                    <ul class="flight">
+                                                        <div class="no">상품번호 ${itemId}</div>
+                                                        <img src="/tour-ranger/airlines/${airlineId}" style="width: 25px;height: 25px">${airlineName}
+                                                        <strong>${formattedDiscountPrice}</strong><em>원 ~</em>
+                                                        <button class="btn-type-1 color--black" name="btnDetail" data-no="1" data-id="${itemId}"
+                                                                value="${itemId}" onclick="showItemButton(this)">자세히보기
+                                                        </button>
+                                                    </ul>
+
+                                            </div>
+                                        </div>
+                                    </div>`
+                    $('#itemTableBody').append(temp_html);
+                });
+            }).catch(function (error) {
+            console.error("Item 리스트 불러오기 실패", error);
+        })
+    }
+
+    function showItemButton(button) {
+        let itemId = button.value;
+        window.location.href = "/tour-ranger/front/items/" + itemId;
+    }
+
+    function updatePaginationButtons(totalPages) {
+        const pagination = document.getElementById("pagination");
+        pagination.innerHTML = "";
+
+        for (let i = 0; i < totalPages; i++) {
+            const button = document.createElement("button");
+            button.innerText = i + 1;
+            button.addEventListener("click", () => {
+                currentPage = i;
+                displayItems(currentPage, itemsPerPage);
+            });
+            pagination.appendChild(button);
+        }
+    }
+
+    window.onload = function () {
+        const initialPage = 0; // 초기 페이지
+        displayItems(initialPage, itemsPerPage); // 아이템 데이터 불러오기
+    };
+
+</script>
 </body>
+
+
 </html>


### PR DESCRIPTION
## 관련 Issue

* #34 

## 변경 사항
- 배너페이지에서 ItemList와 페이지네이션 기능 구현(1페이지당 Item 5건 조회)
- 검색 기능 구현
    - 상품명 기준으로 조회. 조회 시 `최신순`, `최저가순`, `최고가순` 조건 설정 선택 가능
    - 추후 최적화 고려하여, 현재는 JPA 사용하여 구현했습니다. ex) `findByNameContainingOrderByIdDesc`
- Item 내 자세히보기 버튼을 통해 Item상세페이지로 이동

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/131952511/dbd9c858-929f-4429-9cc5-05e3b5e7f1b1)
현재 페이지네이션 기능 중 Next버튼을 클릭 시, 현재 페이지 기준 +1페이지의 내용이 조회되게끔 구현했습니다. 
- 총 페이지 이상으로는 이동하지 못하도록 하는 로직이 필요합니다. 현재는 총 페이지를 계산하는 로직이 없습니다.

## 트러블 슈팅
### Pageable 내 sort가 존재하는 문제
조회 시, queryString을 이용하여 uri에 name(검색어에 입력한 이름), sort(정렬기준), page(페이지번호),size(페이지당 아이템크기)를 구현했었다.
```
fetch(`/tour-ranger/items?search=${search}&sort=${sort}&page=${page}&size=${size}`)
```

하지만 sort를 Pageable에서 받아들여, 검색을 통한 조회가 안되는 문제가 있었다.

#### 해결 방안
`sort` 대신 `condition` 사용
```
fetch(`/tour-ranger/items?search=${search}&condition=${condition}&page=${page}&size=${size}`)
```

## 페이지
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/131952511/2cef88d8-b9a6-4320-81ab-73fd6b14a8ed)
한 페이지당 5item씩 조회

![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/131952511/90ad72e9-30bf-499e-aae3-82032c29c3dd)
검색 시, 입력한 내용이 포함된 item 조회

![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/131952511/ad6d92c1-85ac-4b95-9a1a-fbb7bf6d376f)
자세히보기 버튼 클릭을 통해 상품 상세페이지 이동