### PR TITLE
[refactor] ItemList조회 속도 개선

### DIFF
--- a/src/main/java/com/tourranger/item/repository/ItemRepository.java
+++ b/src/main/java/com/tourranger/item/repository/ItemRepository.java
@@ -1,25 +1,29 @@
 package com.tourranger.item.repository;
 
-import com.tourranger.item.entity.Item;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.tourranger.item.entity.Item;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
 	Optional<Item> findTopByOrderByIdDesc();
 
-	Page<Item> findAllByOrderById(Pageable pageable);
-
 	//이름검색(조건-최신순)
-	Page<Item> findByNameContainingOrderByIdDesc(String search, Pageable pageable);
+	@Query(value = "SELECT * FROM item i WHERE MATCH(i.name) AGAINST(:search IN BOOLEAN MODE) ORDER BY i.id DESC", nativeQuery = true)
+	Page<Item> searchItemOrderbyIdDesc(String search, Pageable pageable);
 
 	//이름검색(조건-가격 낮은순)
-	Page<Item> findByNameContainingOrderByDiscountPrice(String search, Pageable pageable);
+	@Query(value = "SELECT * FROM item i WHERE MATCH(i.name) AGAINST(:search IN BOOLEAN MODE) ORDER BY i.discount_price", nativeQuery = true)
+	Page<Item> searchItemOrderbyDiscountPrice(String search, Pageable pageable);
 
 	//이름검색(조건-가격 높은순)
-	Page<Item> findByNameContainingOrderByDiscountPriceDesc(String search, Pageable pageable);
+	@Query(value = "SELECT * FROM item i WHERE MATCH(i.name) AGAINST(:search IN BOOLEAN MODE) ORDER BY i.discount_price DESC", nativeQuery = true)
+	Page<Item> searchItemOrderbyDiscountPriceDesc(String search, Pageable pageable);
 }
+

--- a/src/main/java/com/tourranger/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/tourranger/item/repository/ItemRepositoryCustom.java
@@ -1,4 +1,12 @@
 package com.tourranger.item.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.tourranger.item.entity.Item;
+
 public interface ItemRepositoryCustom {
+
+	//메인페이지 상품 조회
+	Page<Item> findAllByOrderById(Pageable pageable);
 }

--- a/src/main/java/com/tourranger/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/com/tourranger/item/repository/ItemRepositoryImpl.java
@@ -1,11 +1,41 @@
 package com.tourranger.item.repository;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tourranger.item.entity.Item;
+import com.tourranger.item.entity.QItem;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class ItemRepositoryImpl implements ItemRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
+	QItem item = QItem.item;
+	@Override
+	public Page<Item> findAllByOrderById(Pageable pageable){
+		Long startId = pageable.getOffset()+ 1;
+		Long endId = startId+4;
+		JPAQuery<Item> query = queryFactory.selectFrom(item)
+			.where(
+				item.id.between(startId, endId)
+			)
+			.orderBy(item.id.asc());
+
+		List<Item> itemList = query.fetch();
+
+		long totalCount = query.fetchCount();//결과의 총 갯수
+
+		return new PageImpl<>(itemList, pageable, totalCount);
+	}
+
 }
+
+

--- a/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
@@ -40,7 +40,6 @@ public class ItemServiceImpl implements ItemService {
         else{
             keyword = search;
         }
-        System.out.println(keyword);
 
         return switch (condition) {
             case "latest" -> // 최신순

--- a/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/tourranger/item/service/ItemServiceImpl.java
@@ -1,15 +1,17 @@
 package com.tourranger.item.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
 import com.tourranger.common.error.CustomErrorCode;
 import com.tourranger.common.exception.CustomException;
 import com.tourranger.item.dto.ItemResponseDto;
 import com.tourranger.item.entity.Item;
 import com.tourranger.item.repository.ItemRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -31,14 +33,22 @@ public class ItemServiceImpl implements ItemService {
 
     @Override
     public List<ItemResponseDto> getSearchedItemList(String search, String condition, Pageable pageable) {
+        String keyword;
+        if(search.length()>2){
+            keyword = splitSearchKeywordForNgram(search);
+        }
+        else{
+            keyword = search;
+        }
+        System.out.println(keyword);
 
         return switch (condition) {
             case "latest" -> // 최신순
-                    itemRepository.findByNameContainingOrderByIdDesc(search, pageable).stream().map(ItemResponseDto::new).toList();
+                    itemRepository.searchItemOrderbyIdDesc(keyword, pageable).stream().map(ItemResponseDto::new).toList();
             case "priceLowToHigh" -> // 가격 낮은순
-                    itemRepository.findByNameContainingOrderByDiscountPrice(search, pageable).stream().map(ItemResponseDto::new).toList();
+                    itemRepository.searchItemOrderbyDiscountPrice(keyword, pageable).stream().map(ItemResponseDto::new).toList();
             case "priceHighToLow" -> // 가격 높은순
-                    itemRepository.findByNameContainingOrderByDiscountPriceDesc(search, pageable).stream().map(ItemResponseDto::new).toList();
+                    itemRepository.searchItemOrderbyDiscountPriceDesc(keyword, pageable).stream().map(ItemResponseDto::new).toList();
             default -> null;
         };
     }
@@ -48,5 +58,23 @@ public class ItemServiceImpl implements ItemService {
                 new CustomException(CustomErrorCode.ITEM_NOT_FOUND, null)
         );
     }
+    public String splitSearchKeywordForNgram(String search) {
+        // 공백을 기준으로 문자열 분리
+        String[] tokens = search.split(" ");
 
+        // n-gram 형식으로 변환
+        StringBuilder ngramSearch = new StringBuilder();
+        for (int i = 0; i < tokens.length; i++) {
+            for (int j = 0; j < tokens[i].length(); j++) {
+                if (j + 2 <= tokens[i].length()) {
+                    if (ngramSearch.length() > 0) {
+                        ngramSearch.append(" ");
+                    }
+                    ngramSearch.append("+").append(tokens[i].substring(j, j + 2));
+                }
+            }
+        }
+
+        return ngramSearch.toString();
+    }
 }

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -157,7 +157,6 @@
         let search = document.getElementById("search").value;
         let condition = document.getElementById("condition").value;
         searched = true;
-        console.log("검색버튼 클릭")
         fetch(`/tour-ranger/items?search=${search}&condition=${condition}&page=${page}&size=${size}`)
             .then(function (response) {
                 return response.json();

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -28,7 +28,7 @@
         <div class="col-md-4">
             <form class="form-inline">
                 <input type="text" id="search" class="form-control mr-2" placeholder="상품 이름으로 검색">
-                <button type="submit" class="btn btn-primary" onclick="searchItems(0,5)">검색</button>
+                <button type="button" class="btn btn-primary" onclick="searchItems(0,5)">검색</button>
                 <div class="col-md-2 mt-3 mt-md-0">
                     <select id="condition" class="form-control">
                         <option value="latest">최신순</option>
@@ -157,7 +157,7 @@
         let search = document.getElementById("search").value;
         let condition = document.getElementById("condition").value;
         searched = true;
-
+        console.log("검색버튼 클릭")
         fetch(`/tour-ranger/items?search=${search}&condition=${condition}&page=${page}&size=${size}`)
             .then(function (response) {
                 return response.json();


### PR DESCRIPTION
## 관련 Issue
* #47 

## 변경 사항
-  메인페이지 접근 및 페이지네이션 시 발생하는 ItemList 조회 쿼리 개선
기존 : offset(페이지번호), limit(페이지사이즈)를 이용한 페이징쿼리 사용
변경 : 페이지번호에 따라 Id 범위를 지정하여 조회
조회속도 45s -> 100ms내외로 개선

- 검색쿼리 조회속도 개선
기존 : LIKE를 통한 조회
변경 : FullText index(ngram)이용한 조회

**조회속도는 현재 데이터량에 따라 상이한 결과를 보이고 있습니다.**
- 로컬환경 (item데이터 9,150,029 row)에서 조회 속도 테스트 결과

도시명 | 데이터량(count) | 차지 비율 | LIKE문 조회속도 | FullText 조회속도
-- | -- | -- | -- | --
나트랑|804,600 | 8.7% | 16.82s | 23.08s
푸꾸옥|304,440 | 3.3% | 16.71s | 8.96s
태국|89,520 | 0.9% | 16.94s | 6.19s
오사카|81,540 | 0.89% | 19.37s | 2.42s
도쿄|63,240 | 0.6% | 16.59s | 2.50s
파리|57,390 | 0.6% | 16.83s | 4.45s
유럽|29,660 | 0.3% | 16.78s | 692.38ms
이탈리아|7,140 | 0.078% | 17.62s | 946.70ms
브라질|180 | 0.001% | 16.59s | 185.56ms

**FullText index 조회 수행을 위해 사용할 DB 테이블에 FullText index를 추가하는 아래 작업이 필요합니다.**

```SQL
ALTER TABLE item
ADD FULLTEXT INDEX idx_ngram_name (name) WITH PARSER ngram;
```


## 트러블 슈팅
### 검색단어 수에 따른 조회속도 차이
- ngram의 기본 token사이즈는 2  `SHOW GLOBAL VARIABLES like '%ngram_token_size%'`
- token사이즈보다 긴 검색어를 입력 시, Like문을 사용한 조회속도보다 훨씬 느려지게 된다.

### 해결 방법 
아래와 같은 SQL문이 동작하도록 Token Size(2)에 맞게 search문을 가공하는 메서드 추가
```SQL
SELECT * 
FROM T_BOARD
WHERE MATCH(TITLE) AGAINST('+푸꾸 +꾸옥' IN BOOLEAN MODE)
//7.4s
```

```java
    public String splitSearchKeywordForNgram(String search) {
        // 공백을 기준으로 문자열 분리
        String[] tokens = search.split(" ");

        // n-gram 형식으로 변환
        StringBuilder ngramSearch = new StringBuilder();
        for (int i = 0; i < tokens.length; i++) {
            for (int j = 0; j < tokens[i].length(); j++) {
                if (j + 2 <= tokens[i].length()) {
                    if (ngramSearch.length() > 0) {
                        ngramSearch.append(" ");
                    }
                    ngramSearch.append("+").append(tokens[i].substring(j, j + 2));
                }
            }
        }

        return ngramSearch.toString();
    }
```


