### PR TITLE
[feature] 멀티스레드 사용

### DIFF
--- a/src/main/java/com/tourranger/TourRangerApplication.java
+++ b/src/main/java/com/tourranger/TourRangerApplication.java
@@ -2,10 +2,11 @@ package com.tourranger;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class TourRangerApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(TourRangerApplication.class, args);
 	}

--- a/src/main/java/com/tourranger/common/config/AsyncConfig.java
+++ b/src/main/java/com/tourranger/common/config/AsyncConfig.java
@@ -6,22 +6,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import lombok.Value;
-
 @Configuration
 public class AsyncConfig {
-	private int CORE_POOL_SIZE = Integer.parseInt(System.getenv("CORE_POOL_SIZE"));
-	private int MAX_POOL_SIZE = Integer.parseInt(System.getenv("MAX_POOL_SIZE"));
-	private int QUEUE_CAPACITY = Integer.parseInt(System.getenv("QUEUE_CAPACITY"));
-	private String THREAD_NAME_PREFIX = System.getenv("THREAD_NAME_PREFIX");
-
 	@Bean(name = "taskExecutor")
 	public Executor taskExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(CORE_POOL_SIZE); // 스레드 풀의 핵심(core) 스레드 수
-		executor.setMaxPoolSize(MAX_POOL_SIZE); // 스레드 풀의 최대 스레드 수
-		executor.setQueueCapacity(QUEUE_CAPACITY); // 대기 큐의 최대 용량
-		executor.setThreadNamePrefix(THREAD_NAME_PREFIX); // 스레드 이름 접두사
+		executor.setCorePoolSize(4); // 기본 스레드 수
+		executor.setMaxPoolSize(8); // 최대 스레드 수
+		executor.setQueueCapacity(100); // 대기 큐의 최대 사이즈
+		executor.setThreadNamePrefix("Thread Number-"); // 스레드 이름 접두사
 		executor.initialize(); // 스레드 풀을 초기화
 		return executor;
 	}

--- a/src/main/java/com/tourranger/common/config/AsyncConfig.java
+++ b/src/main/java/com/tourranger/common/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package com.tourranger.common.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import lombok.Value;
+
+@Configuration
+public class AsyncConfig {
+	private int CORE_POOL_SIZE = Integer.parseInt(System.getenv("CORE_POOL_SIZE"));
+	private int MAX_POOL_SIZE = Integer.parseInt(System.getenv("MAX_POOL_SIZE"));
+	private int QUEUE_CAPACITY = Integer.parseInt(System.getenv("QUEUE_CAPACITY"));
+	private String THREAD_NAME_PREFIX = System.getenv("THREAD_NAME_PREFIX");
+
+	@Bean(name = "taskExecutor")
+	public Executor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(CORE_POOL_SIZE); // 스레드 풀의 핵심(core) 스레드 수
+		executor.setMaxPoolSize(MAX_POOL_SIZE); // 스레드 풀의 최대 스레드 수
+		executor.setQueueCapacity(QUEUE_CAPACITY); // 대기 큐의 최대 용량
+		executor.setThreadNamePrefix(THREAD_NAME_PREFIX); // 스레드 이름 접두사
+		executor.initialize(); // 스레드 풀을 초기화
+		return executor;
+	}
+}

--- a/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
+++ b/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.tourranger.purchase.service;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,9 +25,10 @@ public class PurchaseServiceImpl implements PurchaseService {
 
 	@Override
 	@Transactional
+	@Async("taskExecutor")
 	public void purchaseItem(Long itemId, PurchaseRequestDto requestDto) {
 		User user = userService.findUser(requestDto.getEmail());
-		Item item= itemService.findItemPessimisticLock(itemId);
+		Item item = itemService.findItemPessimisticLock(itemId);
 		checkStock(item);
 		Purchase purchase = Purchase.builder().item(item).user(user).build();
 		purchaseRepository.save(purchase);

--- a/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
+++ b/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
@@ -31,15 +31,15 @@ public class PurchaseServiceImpl implements PurchaseService {
 	@Transactional
 	@Async("taskExecutor")
 	public void purchaseItem(Long itemId, PurchaseRequestDto requestDto) {
-		String threadName = Thread.currentThread().getName(); // 현재 스레드의 이름 가져오기
-		logger.info("start purchaseItem(), " + threadName);
+		// String threadName = Thread.currentThread().getName(); // 현재 스레드의 이름 가져오기
+		// logger.info("start purchaseItem(), " + threadName);
 		User user = userService.findUser(requestDto.getEmail());
 		Item item = itemService.findItemPessimisticLock(itemId);
 		checkStock(item);
 		Purchase purchase = Purchase.builder().item(item).user(user).build();
 		purchaseRepository.save(purchase);
 		item.sellOne();
-		logger.info("end purchaseItem(), " + threadName);
+		// logger.info("end purchaseItem(), " + threadName);
 	}
 
 	private void checkStock(Item item) {

--- a/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
+++ b/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
@@ -1,5 +1,7 @@
 package com.tourranger.purchase.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,16 +25,21 @@ public class PurchaseServiceImpl implements PurchaseService {
 	private final ItemServiceImpl itemService;
 	private final PurchaseRepository purchaseRepository;
 
+	private static final Logger logger = LoggerFactory.getLogger(PurchaseServiceImpl.class);
+
 	@Override
 	@Transactional
 	@Async("taskExecutor")
 	public void purchaseItem(Long itemId, PurchaseRequestDto requestDto) {
+		String threadName = Thread.currentThread().getName(); // 현재 스레드의 이름 가져오기
+		logger.info("start purchaseItem(), " + threadName);
 		User user = userService.findUser(requestDto.getEmail());
 		Item item = itemService.findItemPessimisticLock(itemId);
 		checkStock(item);
 		Purchase purchase = Purchase.builder().item(item).user(user).build();
 		purchaseRepository.save(purchase);
 		item.sellOne();
+		logger.info("end purchaseItem(), " + threadName);
 	}
 
 	private void checkStock(Item item) {


### PR DESCRIPTION
## 관련 이슈
* #66 

### AsyncConfig
```java
@Configuration
public class AsyncConfig {
	@Bean(name = "taskExecutor")
	public Executor taskExecutor() {
		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
		executor.setCorePoolSize(4); // 기본 스레드 수
		executor.setMaxPoolSize(8); // 최대 스레드 수
		executor.setQueueCapacity(100); // 대기 큐의 최대 사이즈
		executor.setThreadNamePrefix("Thread Number-"); // 스레드 이름 접두사
		executor.initialize(); // 스레드 풀을 초기화
		return executor;
	}
}
```
- CPU 1코어 = 1스레드가 가장 적합하기 때문에, 기본 스레드를 4로 지정해주었고, 최대 스레드는 2배정도로 잡아주었다. → AWS에서 4 vCPU 성능의 인스턴스를 사용하고자 함
```
기본 스레드 - 4
최대 스레드 - 8
대기 큐 - 100
```
### `@Async("taskExecutor")`
> 앞의 `AsyncConfig`에서 생성한 `taskExecutor` bean을 `@Async`와 함께 주입한다.
```
@Override
@Transactional
@Async("taskExecutor")
public void purchaseItem(Long itemId, PurchaseRequestDto requestDto) {
```

### Postman 테스트
#### 공통: Run Configration
> 총 1천개의 구매 요청(HTTP POST)이 들어갑니다 (+ 1ms의 딜레이 타임)
```
Iterations = 1000
Delay = 1 ms
```
#### 공통: body (JSON 타입)
- 정보를 넘길 때 사용할 `{{email}}`은 .csv 파일로 넘겨준다 - 여기서는 email 정보만 사용하기 때문에, .csv 파일에도 email 정보만 있어야한다.
```
{
  "email": "{{email}}"
}
```
#### 결과 (멀티스레드 사용)
> 평균 처리시간 2ms
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/119802267/914818a6-4c57-4b98-baf4-e08aac5cae08)

#### 결과 (멀티스레드 미사용)
> 평균 처리시간 32ms
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/119802267/33263619-32ac-4d99-9877-81eb9e80dbb3)
