### PR TITLE
[feature] 회원가입, 로그인 - 멀티 로그인 방지, 레디스 - 세션 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,14 @@ repositories {
 }
 
 dependencies {
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
+
     // AWS S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
 

--- a/src/main/java/com/tourranger/common/config/PasswordConfig.java
+++ b/src/main/java/com/tourranger/common/config/PasswordConfig.java
@@ -2,6 +2,8 @@ package com.tourranger.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class PasswordConfig {

--- a/src/main/java/com/tourranger/common/config/PasswordConfig.java
+++ b/src/main/java/com/tourranger/common/config/PasswordConfig.java
@@ -1,0 +1,12 @@
+package com.tourranger.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PasswordConfig {
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/com/tourranger/common/error/CustomErrorCode.java
+++ b/src/main/java/com/tourranger/common/error/CustomErrorCode.java
@@ -13,7 +13,8 @@ public enum CustomErrorCode {
 	IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이미지입니다."),
 	TYPE_NOT_IMAGE(HttpStatus.BAD_REQUEST.value(), "파일형식이 이미지파일이 아닙니다."),
 	UPLOAD_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "파일업로드와 이미지 url 중 한가지 방법으로 업로드 해야합니다."),
-	USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 사용자입니다.");
+	USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 사용자입니다."),
+	LOGIN_FAILURE(HttpStatus.UNAUTHORIZED.value(), "로그인 정보가 올바르지 않습니다.");
 	private final int errorCode;
 	private final String errorMessage;
 }

--- a/src/main/java/com/tourranger/common/error/CustomErrorCode.java
+++ b/src/main/java/com/tourranger/common/error/CustomErrorCode.java
@@ -12,7 +12,8 @@ public enum CustomErrorCode {
 	ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 상품입니다."),
 	IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이미지입니다."),
 	TYPE_NOT_IMAGE(HttpStatus.BAD_REQUEST.value(), "파일형식이 이미지파일이 아닙니다."),
-	UPLOAD_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "파일업로드와 이미지 url 중 한가지 방법으로 업로드 해야합니다.");
+	UPLOAD_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "파일업로드와 이미지 url 중 한가지 방법으로 업로드 해야합니다."),
+	USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 사용자입니다.");
 	private final int errorCode;
 	private final String errorMessage;
 }

--- a/src/main/java/com/tourranger/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/tourranger/common/security/UserDetailsImpl.java
@@ -1,0 +1,66 @@
+package com.tourranger.common.security;
+
+import com.tourranger.user.entity.User;
+import com.tourranger.user.entity.UserRoleEnum;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+
+	private final User user;
+
+	public UserDetailsImpl(User user) {
+		this.user = user;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	// Authentication
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		UserRoleEnum role = user.getRole();
+		String authority = role.getAuthority();
+
+		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/tourranger/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/tourranger/common/security/UserDetailsServiceImpl.java
@@ -1,0 +1,24 @@
+package com.tourranger.common.security;
+
+import com.tourranger.user.entity.User;
+import com.tourranger.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		User user = userRepository.findByEmail(email)
+				.orElseThrow(() -> new UsernameNotFoundException("Not Found " + email));
+
+		return new UserDetailsImpl(user);
+	}
+}

--- a/src/main/java/com/tourranger/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/tourranger/common/security/WebSecurityConfig.java
@@ -1,0 +1,80 @@
+package com.tourranger.common.security;
+
+import com.tourranger.common.error.CustomErrorCode;
+import com.tourranger.common.exception.CustomException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true)
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+		return configuration.getAuthenticationManager();
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		// CSRF 사용 X
+		http.csrf((csrf) -> csrf.disable());
+
+		// 세션 필요할 때 사용
+		http.sessionManagement(
+				(sessionManagement) -> sessionManagement
+						.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+						.maximumSessions(1)    // 최대 허용 가능 세션 수
+						.maxSessionsPreventsLogin(false)    // 멀티로그인 차단, false : 기존 세션 만료(default)
+		);
+
+		// 모든 API 인가 필터 거치지 않게 설정
+		http.authorizeHttpRequests(
+				(authorizeHttpRequests) -> authorizeHttpRequests
+						.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+						.requestMatchers("/tour-ranger/**").permitAll()
+						.requestMatchers("/image/**").permitAll()
+						.anyRequest().authenticated()
+		);
+
+		// 기본 로그인
+		http.formLogin(
+				(formLogin) -> formLogin
+						.usernameParameter("email")
+						.successHandler(
+								(request, response, authentication) -> {
+									response.sendRedirect("/tour-ranger/");
+								}
+						)
+						.failureUrl("/login")
+						.failureHandler(
+								(request, response, exception) -> {
+									throw new CustomException(CustomErrorCode.LOGIN_FAILURE, null);
+								}
+						)
+		);
+
+//		http.logout((logout) -> logout
+//				.logoutUrl("/logout")
+//				.logoutSuccessUrl("/"));
+
+		return http.build();
+	}
+}

--- a/src/main/java/com/tourranger/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/tourranger/common/security/WebSecurityConfig.java
@@ -2,9 +2,6 @@ package com.tourranger.common.security;
 
 import com.tourranger.common.error.CustomErrorCode;
 import com.tourranger.common.exception.CustomException;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -15,11 +12,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-
-import java.io.IOException;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/tourranger/front/HomeController.java
+++ b/src/main/java/com/tourranger/front/HomeController.java
@@ -20,4 +20,9 @@ public class HomeController {
 	public String tourItem() {
 		return "tourItemPage";
 	}
+
+	@GetMapping("/front/signup")
+	public String signupPage() {
+		return "signupPage";
+	}
 }

--- a/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
+++ b/src/main/java/com/tourranger/purchase/service/PurchaseServiceImpl.java
@@ -34,6 +34,9 @@ public class PurchaseServiceImpl implements PurchaseService {
 		// String threadName = Thread.currentThread().getName(); // 현재 스레드의 이름 가져오기
 		// logger.info("start purchaseItem(), " + threadName);
 		User user = userService.findUser(requestDto.getEmail());
+		if (user == null) {
+			throw new CustomException(CustomErrorCode.USER_NOT_FOUND, null);
+		}
 		Item item = itemService.findItemPessimisticLock(itemId);
 		checkStock(item);
 		Purchase purchase = Purchase.builder().item(item).user(user).build();

--- a/src/main/java/com/tourranger/user/controller/UserController.java
+++ b/src/main/java/com/tourranger/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.tourranger.user.controller;
+
+import com.tourranger.common.dto.ApiResponseDto;
+import com.tourranger.user.dto.SignupRequestDto;
+import com.tourranger.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/tour-ranger")
+@RequiredArgsConstructor
+@RestController
+@Tag(name = "Auth API", description = "사용자의 회원 가입/로그인 API 정보를 담고 있습니다.")
+public class UserController {
+	private final UserService userService;
+
+	@Operation(summary = "회원 가입", description = "SignupRequestDto를 통해 회원이 제출한 정보의 유효성 검사 후 통과 시 DB에 저장하고 성공 메시지를 반환합니다.")
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+		userService.signup(requestDto);
+		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "회원 가입 성공"));
+	}
+
+}

--- a/src/main/java/com/tourranger/user/controller/UserController.java
+++ b/src/main/java/com/tourranger/user/controller/UserController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/tour-ranger")
 @RequiredArgsConstructor
 @RestController
-@Tag(name = "Auth API", description = "사용자의 회원 가입/로그인 API 정보를 담고 있습니다.")
+@Tag(name = "Auth API", description = "사용자의 회원 가입 API 정보를 담고 있습니다.")
 public class UserController {
 	private final UserService userService;
 

--- a/src/main/java/com/tourranger/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/tourranger/user/dto/SignupRequestDto.java
@@ -14,7 +14,6 @@ public class SignupRequestDto {
 
 	@NotBlank
 	@Size(min = 8, max = 15, message = "비밀번호는 최소 8자 이상, 15자 이하여야 합니다.")
-	@Pattern(regexp = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]*$", message = "비밀번호는 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자(_!#$%&'*+/=?`{|}~^.-)로 구성되어야 합니다.")
 	private String password;
 }
 

--- a/src/main/java/com/tourranger/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/tourranger/user/dto/SignupRequestDto.java
@@ -2,7 +2,6 @@ package com.tourranger.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 

--- a/src/main/java/com/tourranger/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/tourranger/user/dto/SignupRequestDto.java
@@ -1,0 +1,20 @@
+package com.tourranger.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SignupRequestDto {
+	@Email
+	@NotBlank
+	private String email;
+
+	@NotBlank
+	@Size(min = 8, max = 15, message = "비밀번호는 최소 8자 이상, 15자 이하여야 합니다.")
+	@Pattern(regexp = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]*$", message = "비밀번호는 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자(_!#$%&'*+/=?`{|}~^.-)로 구성되어야 합니다.")
+	private String password;
+}
+

--- a/src/main/java/com/tourranger/user/entity/User.java
+++ b/src/main/java/com/tourranger/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,13 +16,20 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User {
+public class User implements Serializable {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@Column(nullable = false)
 	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	@Enumerated(value = EnumType.STRING)
+	private UserRoleEnum role;
 
 	@Builder.Default
 	@OneToMany(mappedBy = "user", orphanRemoval = true)

--- a/src/main/java/com/tourranger/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/tourranger/user/entity/UserRoleEnum.java
@@ -1,0 +1,19 @@
+package com.tourranger.user.entity;
+
+public enum UserRoleEnum {
+	USER(Authority.USER);  // 사용자 권한
+	private final String authority;
+
+	UserRoleEnum(String authority) {
+		this.authority = authority;
+	}
+
+	public String getAuthority() {
+		return this.authority;
+	}
+
+	public static class Authority {
+		// 권한 앞에 "ROLE_"을 붙이는 것이 규칙
+		public static final String USER = "ROLE_USER";
+	}
+}

--- a/src/main/java/com/tourranger/user/service/UserService.java
+++ b/src/main/java/com/tourranger/user/service/UserService.java
@@ -1,4 +1,13 @@
 package com.tourranger.user.service;
 
+import com.tourranger.user.dto.SignupRequestDto;
+
 public interface UserService {
+
+	/**
+	 * 회원가입
+	 *
+	 * @param requestDto 회원가입을 위한 요청 정보
+	 */
+	void signup(SignupRequestDto requestDto);
 }

--- a/src/main/java/com/tourranger/user/service/UserServiceImpl.java
+++ b/src/main/java/com/tourranger/user/service/UserServiceImpl.java
@@ -2,19 +2,36 @@ package com.tourranger.user.service;
 
 import com.tourranger.common.error.CustomErrorCode;
 import com.tourranger.common.exception.CustomException;
+import com.tourranger.user.dto.SignupRequestDto;
 import com.tourranger.user.entity.User;
+import com.tourranger.user.entity.UserRoleEnum;
 import com.tourranger.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public void signup(SignupRequestDto requestDto) {
+		User user = findUser(requestDto.getEmail());
+		if (user != null) {
+			throw new CustomException(CustomErrorCode.USER_ALREADY_EXIST, null);
+		}
+		String email = requestDto.getEmail();
+		String password = passwordEncoder.encode(requestDto.getPassword());
+		UserRoleEnum role = UserRoleEnum.USER;
+		User targetUser = User.builder()
+				.email(email).password(password).role(role).build();
+		userRepository.save(targetUser);
+	}
 
 	public User findUser(String email) {
-		return userRepository.findByEmail(email).orElseThrow(() ->
-				new CustomException(CustomErrorCode.USER_NOT_FOUND, null)
-		);
+		return userRepository.findByEmail(email).orElse(null);
 	}
+
 }

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -28,15 +28,15 @@
         padding: 10px; /* 셀 안에 여백 추가 */
     }
 
-    .login-btn {
+    .auth-btn {
         margin: 20px auto 0px auto;
         width: 50px;
     }
 </style>
 <body>
-<div class="login-btn">
-    <button th:href="@{/tour-ranger/front/signup}">signup</button>
-    <button th:href="@{/tour-ranger/login}">login</button>
+<div class="auth-btn">
+    <button onclick="showSignup()">signup</button>
+    <button onclick="showLogin()">login</button>
 </div>
 <div class="container d-flex justify-content-center align-items-center ">
     <a th:href="@{/tour-ranger/front/items/1}">
@@ -206,6 +206,13 @@
     </nav>
 </div>
 <script>
+
+    function showSignup(){
+        window.location.href = "/tour-ranger/front/signup";
+    }
+    function showLogin(){
+        window.location.href = "/tour-ranger/login";
+    }
 
     let itemsPerPage = 5; // 페이지당 아이템 수
     let currentPage = 0; // 현재 페이지

--- a/src/main/resources/templates/bannerPage.html
+++ b/src/main/resources/templates/bannerPage.html
@@ -27,8 +27,17 @@
         border: 1px solid #ccc; /* 셀 테두리 스타일 및 색상 설정 */
         padding: 10px; /* 셀 안에 여백 추가 */
     }
+
+    .login-btn {
+        margin: 20px auto 0px auto;
+        width: 50px;
+    }
 </style>
 <body>
+<div class="login-btn">
+    <button th:href="@{/tour-ranger/front/signup}">signup</button>
+    <button th:href="@{/tour-ranger/login}">login</button>
+</div>
 <div class="container d-flex justify-content-center align-items-center ">
     <a th:href="@{/tour-ranger/front/items/1}">
         <img alt="banner" th:src="@{/image/banner.png}" class="img-fluid"

--- a/src/main/resources/templates/signupPage.html
+++ b/src/main/resources/templates/signupPage.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5">
+    <h2 class="card-title">회원가입</h2>
+    <div class="input-group mb-3">
+        <span class="input-group-text">email</span>
+        <input type="text" class="form-control" id="email" placeholder="email 입력">
+    </div>
+    <div class="input-group mb-3">
+        <span class="input-group-text">password</span>
+        <input type="text" class="form-control" id="password" placeholder="password 입력">
+    </div>
+    <button id="signup-btn">signup</button>
+</div>
+<script>
+    document.getElementById("signup-btn").addEventListener("click", function () {
+        const email = document.getElementById("email").value;
+        const password = document.getElementById("password").value;
+        const requestData = {
+            email: email,
+            password: password
+        }
+        fetch(`/tour-ranger/signup`, {
+          method: "POST",
+          headers: {
+              "Content-Type": "application/json"
+          },
+          body: JSON.stringify(requestData)
+        })
+            .then(response => response.json())
+            .then(data => {
+                if(data.statusCode === 400){
+                    let errorMessage = data.statusMessage;
+                    alert(errorMessage);
+                } else {
+                    alert("회원가입 성공");
+                    window.location.href = "/tour-ranger/";
+                }
+            })
+            .catch(error => {
+                console.error("Error signup: ", error);
+            });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 관련 Issue

* #42
 
<br>

## 변경 사항

변경된 사항들이 좀 많아서 comment로 설명 달아놓겠습니다!

<Br>

## application.properties에 추가해야 할 내용

```java
spring.session.store-type=redis
server.servlet.session.timeout=3600
spring.session.redis.namespace=spring:session

spring.data.redis.password={redis 비밀번호}
spring.data.redis.host=localhost
spring.data.redis.port=6379
```

<br>

## 레디스로 세션 관리 전

Application에서 Edit Configurations를 해서 application 복제 후 Add VM Options로 `-Dserver.port=8080`과 `-Dserver.port=8081`을 추가해줍니다.

|localhost:8080, localhost:8081로 어플리케이션 실행|
|---|
|로그인 창으로 가면 인가가 되어 있지 않은 세션이 생성됩니다.<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/bde738ec-e356-4a7d-ab7e-f1627ae2299f)<br>
DB에 있는 유저의 정보로 로그인을 진행합니다.<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/6414dc50-7a10-4201-bdf4-10a5b4daf8ac)<br>
로그인을 성공하고 인가 정보를 담고 있는 세션이 생성됩니다.<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/1b88f0ff-5d79-46c1-8855-20e95893fc92)<br>
인가 정보를 담고 있는 세션을 가지고 login에 접근하면 다음 창이 뜹니다<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/43417aae-9609-4507-97e1-7395ea2e372d)<br>
`localhost:8081/tour-ranger/login`로 접근을 해보면 세션ID 저장소에서 세션 ID를 불러오지 못하고, 새로운 인가 정보가 없는 세션이 생성되면서 로그인 화면을 불러옵니다.<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/12f53d54-0da1-4989-971d-5b7f42de83d3)|
<br>

## 레디스로 세션 관리 후

|localhost:8080으로 어플리케이션 실행 후 localhost:8081으로 어플리케이션 실행|
|---|
로그인창 -> 인가없는 세션(SESSIONID=`726136...`)<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/ebd4c569-e6f0-400a-a05a-249f8709aad1)<br>
로그인 후 -> 인가된 세션 발급(SESSIONID=`NTE5Yj...`)<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/4a488b1f-cab2-470c-bad3-dcbe338ddaf1)<br>
인가된 세션이라 로그인 창 접속 안됨<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/39ff3743-4daa-47d2-82f2-af22d1768b0a)<br>
`localhost:8081/tour-ranger/login`으로 접속해도 세션ID를 공통 세션 저장소 레디스에서 확인하기 때문에 인가 가능하다.<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/d74b6380-879b-4e76-817c-323744dc9b7e)<br>
레디스에도 인가처리되어 있는 세션이 잘 저장되어 있음을 알 수 있다.<br>
![image](https://github.com/Tour-Ranger/Tour-Ranger-Back/assets/130378232/1761cb99-aac6-4004-9146-76831f059970)|
<br>

## 트러블 슈팅

### User Entity 직렬화

> 일어난 에러

```java
Caused by: java.io.NotSerializableException: com.tourranger.user.entity.User
```

> 원인

User Entity가 직렬화가능하지 않은 클래스라서 발생한 예외

> 해결

Serializable interface를 implements 해줘서 직렬화가능하게 해주었습니다.